### PR TITLE
fix: add notebookId fields to relevant khata validations and models

### DIFF
--- a/models/khata.js
+++ b/models/khata.js
@@ -48,6 +48,10 @@ const KhataSchema = new mongoose.Schema({
 	localId: { type: String },
 	settledFlag: { type: Boolean, default: false },
 	interest: { type: Number, default: 0 },
+	notebookId: {
+		type: mongoose.Schema.Types.ObjectId,
+		ref: 'Notebook',
+	}
 });
 
 const Khata = mongoose.model('Khata', KhataSchema);

--- a/routes/otps.js
+++ b/routes/otps.js
@@ -6,6 +6,7 @@ const { numberSchema, loginSchema } = require('../utils/validations/otpValidatio
 const router = express.Router();
 const { Otp } = require('../models/otp');
 const { User } = require('../models/user');
+const { Notebook } = require('../models/notebook');
 
 const logger = require('../startup/logging');
 
@@ -123,15 +124,28 @@ router.post(
 				user.fcmToken = req.body.fcmToken;
 				const user2 = await user.save();
 				const token = user2.generateAuthToken();
+				await createNotebook(user2)
 				res.header('x-auth-token', token).send(user2);
 			} else {
 				user = new User(req.body);
 				user.fcmToken = req.body.fcmToken;
 				const newuser = await user.save();
 				const token = newuser.generateAuthToken();
+				await createNotebook(newuser)
 				res.header('x-auth-token', token).send(newuser);
 			}
 		}
 	},
 );
+
+async function createNotebook(user) {
+	const name = user.name ?? "User";
+	const result = await Notebook.create({
+		name: `${name}'s Notebook`,
+		description: 'Personal Notebook',
+		ownerId: user._id,
+	})
+	return result
+}
+
 module.exports = router;

--- a/routes/otps.js
+++ b/routes/otps.js
@@ -124,7 +124,6 @@ router.post(
 				user.fcmToken = req.body.fcmToken;
 				const user2 = await user.save();
 				const token = user2.generateAuthToken();
-				await createNotebook(user2)
 				res.header('x-auth-token', token).send(user2);
 			} else {
 				user = new User(req.body);

--- a/utils/validations/khataValidations.js
+++ b/utils/validations/khataValidations.js
@@ -41,6 +41,7 @@ const khataArraySchema = Joi.array().items(
             .required(),
         localId: Joi.string().required(),
         settledFlag: Joi.boolean(),
+        notebookId: Joi.objectId()
     }),
 );
 

--- a/utils/validations/khataValidations.js
+++ b/utils/validations/khataValidations.js
@@ -1,6 +1,8 @@
 const Joi = require('joi');
 Joi.objectId = require('joi-objectid')(Joi);
 
+const mongoose = require('mongoose');
+
 const getKhataSchema = Joi.object({
     lastUpdatedTimeStamp: Joi.date().timestamp('unix'),
     pageSize: Joi.number().integer().max(10000),
@@ -20,6 +22,7 @@ const khataSchema = Joi.object({
     rotationPeriod: Joi.string().valid('0M', '3M', '6M', '18M', '1Y', '2Y'),
     localId: Joi.string().required(),
     settledFlag: Joi.boolean(),
+    notebookId: Joi.objectId()
 });
 
 const khataArraySchema = Joi.array().items(


### PR DESCRIPTION
- create default notebook for user on sign up
- add notebookId fields to relevant khata validations and models. This is an optional field, so, it does not break the current code. We can make it 'required' at some point later when frontend releases support for notebook fields.